### PR TITLE
Suporte para vídeos no quill do admin

### DIFF
--- a/app/views/admin/activities/_content_toolbar.html.erb
+++ b/app/views/admin/activities/_content_toolbar.html.erb
@@ -46,6 +46,9 @@
     <button type="button" class="ql-image"></button>
   </span>
   <span class="ql-formats">
+    <button type="button" class="ql-video"></button>
+  </span>
+  <span class="ql-formats">
     <button type="button" class="ql-divider">
       <span id="span-divider">Divisor</span>
     </button>


### PR DESCRIPTION
Adicionando botão na toolbar do quill que permite embed de vídeos.
<img width="1002" alt="screen shot 2018-10-13 at 18 02 40" src="https://user-images.githubusercontent.com/3386440/46910000-b18d7980-cf12-11e8-9a34-76722fe067e0.png">
O vídeo embedado justworks™ na interface, mas eu vou tentar deixar um pouco mais bonitinho. A mudança aqui deve ser só essa mesmo.
<img width="660" alt="screen shot 2018-10-13 at 18 07 37" src="https://user-images.githubusercontent.com/3386440/46910005-e5689f00-cf12-11e8-8798-36f6ea344b67.png">