### PR TITLE
Remove um erro de digitação no CSS

### DIFF
--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -29,7 +29,6 @@
 
 #span-divider:hover, .ql-divider button:focus, .ql-divider button:hover {
   color: #06c !important;
-  text-shadown: none;
 }
 
 .choices-group {


### PR DESCRIPTION
Na verdade eu tirei a linha toda porque ela aparentemente não fazia nada nem arrumando o typo. Eu testei no inspetor essa propriedade e ela já é heradada do estado sem hover.