### PR TITLE
Definindo os formatos permitidos nos editores de texto

### DIFF
--- a/app/views/admin/activities/_form.html.erb
+++ b/app/views/admin/activities/_form.html.erb
@@ -26,6 +26,22 @@
           modules: {
             toolbar: "#toolbar"
           },
+          formats: [
+            'bold',
+            'italic',
+            'underline',
+            'strike',
+            'link',
+            'blockquote',
+            'header',
+            'image',
+            'list',
+            'sub',
+            'super',
+            'image',
+            'video',
+            'divider'
+          ],
           theme: 'snow'
         }
       }

--- a/app/views/admin/activity_sequences/_form.html.erb
+++ b/app/views/admin/activity_sequences/_form.html.erb
@@ -27,6 +27,9 @@
           modules: {
             toolbar: books_toolbar_options
           },
+          formats: [
+            'link'
+          ],
           theme: 'snow'
         }
       }


### PR DESCRIPTION
Não definir os formatos permitidos estava causando a confusão discutida na issue prefeiturasp/SME-plataforma-curriculo/issues/4. O título e descrição inicial da issue, na verdade, são mais relacionados ao PR #53, mas a discussão abaixo são resolvidas por esse aqui.

O que acontecia é que, ao tentar adicionar links nos textos pelo `admin`, as pessoas frequentemente copiam o texto do link de algum lugar. O editor não estava configurado para impedir certas formatações (como, por exemplo, a cor do texto) e copiava esta formatação junto da origem, criando este tipo de situação:
<img width="1368" alt="screen shot 2018-10-14 at 17 35 57" src="https://user-images.githubusercontent.com/3386440/46921901-a7817e80-cfd7-11e8-8e71-0d6d53dadc4d.png">
Perceba o inline style que está definido no link de baixo, mas não no de cima.

Estas opções configuram o editor para ignorar este tipo de formatação e impedem este tipo de confusão e algumas outras que podem vir a acontecer.

Uma coisa interessante sobre esta mudança é que os textos que já continham texto formatado pelo editor, como o [próprio exemplo que eu usei](http://curriculo.prefeitura.sp.gov.br/sequencia/vibrando-com-o-som) para tirar a screenshot acima, não vão ser ajustados automaticamente. Será necessário abrir o artigo no admin, abrir o editor e salvar as mudanças, sem nem precisar mudar nada, para que o texto seja normalizado.

A solução foi baseada [nesta thread](https://github.com/quilljs/quill/issues/1687).