### PR TITLE
Adicionando filtros na edição de sequências de atividades

### DIFF
--- a/app/admin/activity_sequences.rb
+++ b/app/admin/activity_sequences.rb
@@ -1,5 +1,10 @@
 ActiveAdmin.register ActivitySequence do
   config.sort_order = 'title_asc'
+  config.filters = true
+
+  filter :title
+  filter :presentation_text
+  filter :main_curricular_component
 
   action_item :new, only: :show do
     link_to t('helpers.links.preview'), activity_sequence_preview_path(activity_sequence.slug), target: :_blank


### PR DESCRIPTION
Resolve a issue https://github.com/prefeiturasp/SME-plataforma-curriculo/issues/2.

Segui [esta documentação](https://activeadmin.info/3-index-pages.html) para adicionar três filtros na página de edição de sequências de atividades. Agora é possível filtrar por título, texto de apresentação e componente curricular principal.

<img width="1431" alt="screen shot 2018-10-14 at 18 30 39" src="https://user-images.githubusercontent.com/3386440/46922418-4bbaf380-cfdf-11e8-8435-e7d471734c31.png">
<img width="275" alt="screen shot 2018-10-14 at 18 30 45" src="https://user-images.githubusercontent.com/3386440/46922419-4bbaf380-cfdf-11e8-992d-74834b914bf4.png">
<img width="327" alt="screen shot 2018-10-14 at 18 30 51" src="https://user-images.githubusercontent.com/3386440/46922420-4c538a00-cfdf-11e8-84ca-38514d8835ff.png">
