### PR TITLE
Feature: verify associations before destroy.

### DIFF
--- a/app/admin/survey_forms.rb
+++ b/app/admin/survey_forms.rb
@@ -68,7 +68,22 @@ ActiveAdmin.register SurveyForm do
     end
 
     def update
+      begin
+        super do |format|
+          format.html { redirect_to collection_url and return if resource.valid? }
+          format.json { render json: resource }
+        end
+      rescue
+        flash[:error] = "Erro ao tentar excluir questão: Já existem respostas relacionadas."
+        redirect_to collection_url
+      end
+    end
+
+    def destroy
       super do |format|
+        e = resource.errors.full_messages.to_sentence
+        flash[:error] = "Erro ao tentar deletar: #{e}" if e.present?
+        flash[:error] ||= "Erro ao tentar deletar: Já existem respostas relacionadas." 
         format.html { redirect_to collection_url and return if resource.valid? }
         format.json { render json: resource }
       end

--- a/app/models/survey_form.rb
+++ b/app/models/survey_form.rb
@@ -1,7 +1,7 @@
 class SurveyForm < ApplicationRecord
   belongs_to :public_consultation
   has_many :survey_form_content_blocks, dependent: :destroy
-  has_many :survey_form_answers, dependent: :destroy
+  has_many :survey_form_answers, dependent: :restrict_with_error
 
   accepts_nested_attributes_for :survey_form_content_blocks, allow_destroy: true
 

--- a/app/models/survey_form_content_block.rb
+++ b/app/models/survey_form_content_block.rb
@@ -3,5 +3,5 @@ class SurveyFormContentBlock < ApplicationRecord
   include ContentBlockConcern
 
   belongs_to :survey_form
-  has_many :answers, dependent: :destroy
+  has_many :answers, dependent: :restrict_with_error
 end

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -22,6 +22,9 @@ pt-BR:
       survey_form_content_block: &content_block
         one: "Bloco de conteúdo"
         other: "Blocos de conteúdo"
+      survey_form_answer:
+        one: "Resposta do Formulário"
+        other: "Respostas do Formulário"
       activity_sequences_report: "Relatório das avaliações"
       axis:
         one: "Eixo"
@@ -120,6 +123,7 @@ pt-BR:
         description: "Descrição"
         sequence: "Sequência"
         survey_form_content_blocks: "Blocos de conteúdo"
+        survey_form_answers: "Respostas do Formulário"
       survey_form_content_block: &survey_form_content_block_attrs
         body: "Conteúdo"
         have_rating: "Tem avaliação?"
@@ -127,6 +131,8 @@ pt-BR:
         required_rating: "Avaliação obrigatória?"
         required_comment: "Comentário obrigatório?"
         sequence: "Sequência"
+      survey_form_answer:
+
       activity_content_block: &activity_content_block_attrs
         body: "Conteúdo"
         title: "Título"


### PR DESCRIPTION
# Proposal

This PR aims to verify associations before destroy survey forms and survey forms content blocks.

# Azure card reference

- 19085
- 19086

# Tasks to be reached

- [X] create action destroy.
- [X] verify associations before destroy.
- [X] show flash message with errors.