### PR TITLE
Fix: error message, survey forms order.

### DIFF
--- a/app/admin/survey_forms.rb
+++ b/app/admin/survey_forms.rb
@@ -83,8 +83,12 @@ ActiveAdmin.register SurveyForm do
     def destroy
       super do |format|
         e = resource.errors.full_messages.to_sentence
-        flash[:error] = "Erro ao tentar deletar: #{e}" if e.present?
-        flash[:error] ||= "Erro ao tentar deletar: Já existem respostas relacionadas."
+        flash[:error] = "Erro ao tentar excluir: #{e}" if e.present?
+        begin
+          resource.delete
+        rescue => e
+          flash[:error] = "Erro ao tentar excluir: Já existem respostas relacionadas."
+        end
         format.html { redirect_to collection_url and return if resource.valid? }
         format.json { render json: resource }
       end

--- a/app/views/api/public_consultations/show.json.jbuilder
+++ b/app/views/api/public_consultations/show.json.jbuilder
@@ -7,4 +7,4 @@ json.cover_image "/assets/#{@public_consultation.cover_image_identifier}"
 json.documents @public_consultation.documents_identifiers.map {|d| "/assets/#{d}"}
 json.initial_date @public_consultation.initial_date.strftime("%d/%m/%Y")
 json.final_date @public_consultation.final_date.strftime("%d/%m/%Y")
-json.survey_forms @public_consultation.survey_forms
+json.survey_forms @public_consultation.survey_forms.order(:sequence)


### PR DESCRIPTION
# Proposal

This PR aims to fix survey form ordenation in JSON response and error message when trying to delete.

# Azure card reference

- none

# Tasks to be reached

- [X] fix error message.
- [X] fix JSON response.