### PR TITLE
Fix: set default anonymous for new survey form answer.

### DIFF
--- a/app/views/api/survey_form_answers/new.json.jbuilder
+++ b/app/views/api/survey_form_answers/new.json.jbuilder
@@ -1,5 +1,5 @@
 json.id @survey_form_answer.id
-json.anonymous @survey_form_answer.anonymous
+json.anonymous false
 json.finished @survey_form_answer.finished
 json.survey_form_id @survey_form_answer.survey_form_id
 json.teacher_id @survey_form_answer.teacher_id


### PR DESCRIPTION
# Proposal

This PR aims to set default anonymous option when create a new survey form answer object.

# Azure card reference

- none

# Tasks to be reached

- [X] fix JSON response.