### PR TITLE
Fix: user admin value.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :recoverable, :rememberable, :trackable,
          :jwt_authenticatable, jwt_revocation_strategy: self
 
+  attribute :admin, default: false
   has_one :teacher, dependent: :destroy
 
   validates :email, presence: true, if: -> { username.blank? }
@@ -45,7 +46,6 @@ class User < ApplicationRecord
     user.name = user_info[:results].first[:nm_pessoa]
     user.email = user_info[:results].first[:email_servidor]
     user.dre = user_info[:results].first[:nm_unidade]
-    user.admin = false
     user.save
   end
 


### PR DESCRIPTION
# Proposal

This PR aims to set default admin value when create a new user.

# Azure card reference

- none

# Tasks to be reached

- [X] set default value for admin attribute.